### PR TITLE
maven: ensure that zip files actually have jar files

### DIFF
--- a/deplist.go
+++ b/deplist.go
@@ -124,15 +124,29 @@ func GetDeps(fullPath string) ([]Dependency, Bitmask, error) {
 						})
 				}
 			default:
-
 				ext := filepath.Ext(filename)
-
 				// java
-				if ext == ".jar" || ext == ".war" || ext == ".ear" || ext == ".adm" || ext == ".hpi" || ext == ".zip" {
+				switch ext {
+				case ".zip":
+					// be more aggressive with zip files, must contain something java ish
+					if ok, _ := utils.ZipContainsJava(path); !ok {
+						return nil
+					}
+					fallthrough
+				case ".jar":
+					fallthrough
+				case ".war":
+					fallthrough
+				case ".ear":
+					fallthrough
+				case ".adm":
+					fallthrough
+				case ".hpi":
 					file := strings.Replace(filepath.Base(path), ext, "", 1) // get filename, check if we can ignore
 					if strings.HasSuffix(file, "-sources") || strings.HasSuffix(file, "-javadoc") {
 						return nil
 					}
+
 					pkgs, err := scan.GetJarDeps(path)
 					if err == nil {
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,5 +1,10 @@
 package utils
 
+import (
+	"archive/zip"
+	"path/filepath"
+)
+
 // BelongsToIgnoreList is fastest way we can do a string compare on a list
 func BelongsToIgnoreList(needle string) bool {
 	switch needle {
@@ -25,4 +30,28 @@ func CharIsDigit(c string) bool {
 		return false
 	}
 	return true
+}
+
+// Quickly scan for java files within the zip file
+func ZipContainsJava(path string) (bool, error) {
+	read, err := zip.OpenReader(path)
+	if err != nil {
+		return false, err
+	}
+	defer read.Close()
+
+	for _, f := range read.File {
+		switch filepath.Ext(f.Name) {
+		case ".java":
+			fallthrough
+		case ".war":
+			fallthrough
+		case ".ear":
+			fallthrough
+		case ".jar":
+			return true, nil
+		}
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
This should help minimize deplist falsely trying to consider random zips as maven zip files. 