### PR TITLE
Scan 'src' subdirectory too

### DIFF
--- a/deplist.go
+++ b/deplist.go
@@ -60,8 +60,7 @@ func GetLanguageStr(bm Bitmask) string {
 	return "unknown"
 }
 
-// GetDeps scans a given repository and returns all dependencies found in a DependencyList struct.
-func GetDeps(fullPath string) ([]Dependency, Bitmask, error) {
+func getDeps(fullPath string) ([]Dependency, Bitmask, error) {
 	// var deps DependencyList
 	var deps []Dependency
 	var foundTypes Bitmask = 0
@@ -298,4 +297,18 @@ func GetDeps(fullPath string) ([]Dependency, Bitmask, error) {
 	}
 
 	return deps, foundTypes, nil
+}
+
+// GetDeps scans a given repository and returns all dependencies found in a DependencyList struct.
+func GetDeps(fullPath string) ([]Dependency, Bitmask, error) {
+	deps, foundTypes, err := getDeps(fullPath)
+	if err != nil {
+		return deps, foundTypes, err
+	}
+	// if no deps found, check one level lower in 'src' directory
+	if len(deps) == 0 {
+		deps, foundTypes, err = getDeps(filepath.Join("src", fullPath))
+	}
+
+	return deps, foundTypes, err
 }


### PR DESCRIPTION
Only scan "src" subdir if no deps found in top level. Assists with rpm builds like `golang-1.16.12-1.module+el8.5.0+13637+960c7771`:

```
$ ls
api/            CONTRIBUTING.md  favicon.ico  misc/                   README.md    src/
AUTHORS         CONTRIBUTORS     lib/         PATENTS                 robots.txt   test/
codereview.cfg  doc/             LICENSE      README.boringcrypto.md  SECURITY.md  VERSION
```

Before:

```
$ deplist .
$
```

After: 

```
$ deplist . 
pkg:go/image/color/palette
pkg:go/std/net/http/httputil
pkg:go/internal/reflectlite
pkg:go/bytes
...
```