### PR TITLE
Prevent fatal error when handling non-directory paths

### DIFF
--- a/deplist.go
+++ b/deplist.go
@@ -1,6 +1,7 @@
 package deplist
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -295,21 +296,24 @@ func getDeps(fullPath string) ([]Dependency, Bitmask, error) {
 }
 
 // findBaseDir walks a directory tree through empty subdirs til it finds a directory with content
-func findBaseDir(fullPath string) string {
+func findBaseDir(fullPath string) (string, error) {
 	log.Debugf("Checking %s", fullPath)
 	files, err := ioutil.ReadDir(fullPath)
 	if err != nil {
-		log.Fatal(err)
+		return "", fmt.Errorf("Could not read: %s", err)
 	}
 	if len(files) == 1 && files[0].IsDir() {
 		return findBaseDir(filepath.Join(fullPath, files[0].Name()))
 	}
-	return fullPath
+	return fullPath, nil
 }
 
 // GetDeps scans a given repository and returns all dependencies found in a DependencyList struct.
 func GetDeps(fullPath string) ([]Dependency, Bitmask, error) {
-	fullPath = findBaseDir(fullPath)
+	fullPath, err := findBaseDir(fullPath)
+	if err != nil {
+		return nil, 0, err
+	}
 
 	deps, foundTypes, err := getDeps(fullPath)
 	if err != nil {


### PR DESCRIPTION
This was causing fatal errors when attempting to handle paths that weren't directories. Occurs with some RPMs, that when rebuilt with `rpmbuild -bp <spec>` don't create a new dir, only regular files, e.g.
```
$ deplist ~/rpmbuild/BUILD/gpl-2.0.txt
FATA[0000] readdirent /home/sfowler/rpmbuild/BUILD/gpl-2.0.txt: not a directory
```