### PR TITLE
switch to using rbenv for ruby version management

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ On Fedora:
 $ dnf install -y golang-bin yarnpkg maven rubygem-bundler npm
 ```
 
+
+You also need rbenv installed and in your path.
+
 ## Command Line
 
 ### Build from source

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ dnf install -y golang-bin yarnpkg maven rubygem-bundler npm
 ```
 
 
-You also need rbenv installed. Any installed ruby versions will be used as backups from starting with system ruby (if available), and then from newest to oldest.
+Also supports `rbenv`. Any ruby versions installed with `rbenv` will be used as backups from starting with system ruby (if available), and then from newest to oldest.
 
 ## Command Line
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ dnf install -y golang-bin yarnpkg maven rubygem-bundler npm
 ```
 
 
-You also need rbenv installed and in your path.
+You also need rbenv installed. Any installed ruby versions will be used as backups from starting with system ruby (if available), and then from newest to oldest.
 
 ## Command Line
 

--- a/internal/scan/ruby.go
+++ b/internal/scan/ruby.go
@@ -1,7 +1,6 @@
 package scan
 
 import (
-	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,44 +9,58 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// var RUBY_VERSIONS []string = []string{"system", "2.6.8"}
+
 // GetRubyDeps uses `bundle update --bundler` to list ruby dependencies when a
 // Gemfile.lock file exists
 func GetRubyDeps(path string) (map[string]string, error) {
-	log.Debugf("GetRubyDeps %s", path)
+	return GetRubyDepsWithVersion(path, "system")
+}
+
+func setRbenvVersion(version string, cmd *exec.Cmd) {
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "RBENV_VERSION="+version)
+}
+
+func GetRubyDepsWithVersion(path, version string) (map[string]string, error) {
+	if version != "system" {
+		log.Debugf("retrying with ruby%v \n -> GetRubyDeps %s", version, path)
+	} else {
+		log.Debugf("GetRubyDeps %s", path)
+	}
+
 	gathered := make(map[string]string)
 
 	dirPath := filepath.Dir(path)
 
-	// override the gem path otherwise might hit perm issues and it's annoying
-	gemPath, err := os.MkdirTemp("", "gem_vendor")
-	if err != nil {
-		return nil, err
-	}
-
-	// cleanup after ourselves
-	defer os.RemoveAll(gemPath)
-
 	//Make sure that the Gemfile we are loading is supported by the version of bundle currently installed.
 	cmd := exec.Command("bundle", "update", "--bundler")
 	cmd.Dir = dirPath
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "BUNDLE_PATH="+gemPath)
+	setRbenvVersion(version, cmd)
+
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Debug(string(output))
-		return nil, err
+		if version == "2.6.8" {
+			return nil, err
+		}
+		return GetRubyDepsWithVersion(path, "2.6.8")
 	}
 
 	cmd = exec.Command("bundle", "list")
 
 	cmd.Dir = dirPath
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "BUNDLE_PATH="+gemPath)
+	setRbenvVersion(version, cmd)
 
 	data, err := cmd.Output()
 	if err != nil {
+		log.Debug(err)
 		log.Debug(string(data))
-		return nil, errors.New(gemPath + " " + err.Error())
+
+		if version == "2.6.8" {
+			return nil, err
+		}
+		return GetRubyDepsWithVersion(path, "2.6.8")
 	}
 
 	splitOutput := strings.Split(string(data), "\n")

--- a/internal/scan/ruby.go
+++ b/internal/scan/ruby.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -54,6 +55,10 @@ func GetRubyDeps(path string) (map[string]string, error) {
 
 // GetRubyDepsWithVersion uses `bundle list` to list ruby dependencies when a Gemfile.lock file exists
 func GetRubyDepsWithVersion(path string, version int) (map[string]string, error) {
+	if version >= len(RubyVersions) {
+		log.Debug("GetRubyDeps Failed!")
+		return nil, errors.New("GetRubyDeps Failed: " + "path")
+	}
 	if version != 0 {
 		log.Debug("retrying...")
 	}

--- a/internal/scan/ruby.go
+++ b/internal/scan/ruby.go
@@ -47,12 +47,12 @@ func setRubyVersion(version string, cmd *exec.Cmd) {
 	cmd.Env = append(cmd.Env, "RBENV_VERSION="+version)
 }
 
-// GetRubyDeps uses `bundle update --bundler` to list ruby dependencies when a
-// Gemfile.lock file exists
+// GetRubyDeps calls GetRubyDepsWithVersion with the system ruby version
 func GetRubyDeps(path string) (map[string]string, error) {
 	return GetRubyDepsWithVersion(path, 0)
 }
 
+// GetRubyDepsWithVersion uses `bundle list` to list ruby dependencies when a Gemfile.lock file exists
 func GetRubyDepsWithVersion(path string, version int) (map[string]string, error) {
 	if version != 0 {
 		log.Debug("retrying...")

--- a/internal/scan/ruby.go
+++ b/internal/scan/ruby.go
@@ -25,7 +25,7 @@ func init() {
 		if err != nil {
 			log.Debugf("couldn't install bundler: %v", string(data))
 		}
-		log.Printf("Installed bundler for ruby %v\n", version)
+		log.Debugf("Installed bundler for ruby %v\n", version)
 	}
 }
 
@@ -57,7 +57,7 @@ func GetRubyDeps(path string) (map[string]string, error) {
 func GetRubyDepsWithVersion(path string, version int) (map[string]string, error) {
 	if version >= len(RubyVersions) {
 		log.Debug("GetRubyDeps Failed!")
-		return nil, errors.New("GetRubyDeps Failed: " + "path")
+		return nil, errors.New("GetRubyDeps Failed: " + path)
 	}
 	if version != 0 {
 		log.Debug("retrying...")

--- a/test/testRepo/Gemfile.lock
+++ b/test/testRepo/Gemfile.lock
@@ -185,4 +185,4 @@ DEPENDENCIES
   uuidtools (= 2.1.5)
 
 BUNDLED WITH
-   2.1.4
+   2.3.20


### PR DESCRIPTION
allows installing other version of ruby via rbenv. These versions will be used as backups when trying to parse ruby deps.