### PR TITLE
Minor ruby related updates

### DIFF
--- a/internal/scan/ruby.go
+++ b/internal/scan/ruby.go
@@ -60,12 +60,12 @@ func GetRubyDeps(path string) (map[string]string, error) {
 
 // GetRubyDepsWithVersion uses `bundle list` to list ruby dependencies when a Gemfile.lock file exists
 func GetRubyDepsWithVersion(path string, version int) (map[string]string, error) {
-	if version >= len(RubyVersions) {
-		log.Debug("GetRubyDeps Failed!")
-		return nil, errors.New("GetRubyDeps Failed: all ruby versions failed " + path)
-	}
 	if version != 0 {
 		log.Debug("retrying...")
+	}
+	if version >= len(RubyVersions) {
+		log.Debug("GetRubyDeps Failed! No more ruby versions available")
+		return nil, errors.New("GetRubyDeps Failed: all ruby versions failed " + path)
 	}
 	log.Debugf("GetRubyDeps(%v) %s", RubyVersions[version], path)
 
@@ -90,6 +90,8 @@ func GetRubyDepsWithVersion(path string, version int) (map[string]string, error)
 
 	data, err := cmd.CombinedOutput()
 	if err != nil {
+		log.Debugf("error: %s", err)
+		log.Debugf("error: %v", string(data))
 		return GetRubyDepsWithVersion(path, version+1)
 	}
 

--- a/test/testRepo/Gemfile.lock
+++ b/test/testRepo/Gemfile.lock
@@ -185,4 +185,4 @@ DEPENDENCIES
   uuidtools (= 2.1.5)
 
 BUNDLED WITH
-   2.3.20
+   2.2.23


### PR DESCRIPTION
FYI @cebarks

To support this use-case:
```
$ podman run -v $(realpath ./test/testRepo/):/testRepo:Z localhost/deplist:latest -debug /testRepo
time="2022-08-16T03:35:10Z" level=debug msg="Checking /testRepo"
time="2022-08-16T03:35:10Z" level=debug msg="GetRubyDeps(system) /testRepo/Gemfile.lock"
time="2022-08-16T03:35:19Z" level=debug msg="error: exit status 5"
time="2022-08-16T03:35:19Z" level=debug msg="error: Fetching gem metadata from https://rubygems.org/..........\nstrptime-0.2.4 requires ruby version ~> 2.0, which is incompatible with the\ncurrent version, ruby 3.0.4p208\n"
time="2022-08-16T03:35:19Z" level=debug msg=retrying...
time="2022-08-16T03:35:19Z" level=debug msg="GetRubyDeps Failed! No more ruby versions available"
GetRubyDeps Failed: all ruby versions failed /testRepo/Gemfile.lock
```
